### PR TITLE
Review fixture for Clawdeck's Review Inbox (not for merge)

### DIFF
--- a/demo/review-fixture.mjs
+++ b/demo/review-fixture.mjs
@@ -1,0 +1,33 @@
+// Fixture for verifying Clawdeck's Review Inbox against a real PR.
+// Not merged: this branch exists so review threads can be imported and
+// their anchors checked against later commits.
+
+const DEFAULT_TTL_MS = 60000;
+
+/** Compare a supplied token against the expected one. */
+export function checkToken(supplied, expected) {
+  if (!supplied || !expected) return false;
+  return supplied === expected;
+}
+
+/** Format a duration for display. */
+export function formatMs(ms) {
+  if (ms == null) return "unknown";
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+const cache = new Map();
+
+/** Read a value, caching it for DEFAULT_TTL_MS. */
+export function readCached(key, compute, now = Date.now()) {
+  const hit = cache.get(key);
+  if (hit && now - hit.at < DEFAULT_TTL_MS) return hit.value;
+  const value = compute();
+  cache.set(key, { value, at: now });
+  return value;
+}
+
+export function clearCache() {
+  cache.clear();
+}

--- a/demo/review-fixture.mjs
+++ b/demo/review-fixture.mjs
@@ -1,3 +1,6 @@
+// Reviewed in PR #1; a later commit shifts the lines below.
+import { strict as assert } from "node:assert";
+
 // Fixture for verifying Clawdeck's Review Inbox against a real PR.
 // Not merged: this branch exists so review threads can be imported and
 // their anchors checked against later commits.
@@ -21,7 +24,7 @@ const cache = new Map();
 
 /** Read a value, caching it for DEFAULT_TTL_MS. */
 export function readCached(key, compute, now = Date.now()) {
-  const hit = cache.get(key);
+  const hit = cache.get(String(key));
   if (hit && now - hit.at < DEFAULT_TTL_MS) return hit.value;
   const value = compute();
   cache.set(key, { value, at: now });


### PR DESCRIPTION
Throwaway PR so Clawdeck's Review Inbox can be verified against real review threads.

Three comments will be added:
- a review comment on a line that a later commit changes,
- a review comment on a line a later commit leaves alone, but shifts by inserting lines above it,
- a general conversation comment, which must never count as a delivery blocker.

Nothing here is meant to merge.